### PR TITLE
Implement i2mv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/taubyte/go-sdk v0.1.43
 )
 
+replace github.com/taubyte/go-sdk => ../go-sdk
+
 require (
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/taubyte/go-sdk v0.1.43 h1:eUwe/WoIui3AHsGOF3u7xqmWCSsqJPzh4eXJXvzPAyY=
-github.com/taubyte/go-sdk v0.1.43/go.mod h1:zs3KxftKnszCuwyiHvxWGCWm7W7Ey+amzuQ9R8GhsHo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/i2mv/imports.go
+++ b/i2mv/imports.go
@@ -1,0 +1,22 @@
+//go:build !wasi && !wasm
+// +build !wasi,!wasm
+
+package i2mvSym
+
+import "github.com/taubyte/go-sdk/errno"
+
+var MemoryViewNew = func(bufPtr *byte, size uint32, readCloser uint32, idPtr *uint32) (error errno.Error) {
+	return 0
+}
+
+var MemoryViewRead = func(id uint32, offset uint32, count uint32, bufPtr *byte, nPtr *uint32) (error errno.Error) {
+	return 0
+}
+
+var MemoryViewClose = func(id uint32) (error errno.Error) {
+	return 0
+}
+
+var MemoryViewSize = func(id uint32, sizePtr *uint32) (error errno.Error) {
+	return 0
+}

--- a/i2mv/mocks.go
+++ b/i2mv/mocks.go
@@ -1,0 +1,48 @@
+package i2mvSym
+
+import "github.com/taubyte/go-sdk/errno"
+
+func MockNew(testId int32) {
+	MemoryViewNew = func(bufPtr *byte, size, readCloser uint32, idPtr *uint32) (error errno.Error) {
+		if testId < 0 {
+			return 1
+		}
+
+		*idPtr = uint32(testId)
+
+		return 0
+	}
+}
+
+func MockRead(testId uint32) {
+	MemoryViewRead = func(id, offset, count uint32, bufPtr *byte, nPtr *uint32) (error errno.Error) {
+		if testId != id {
+			return 1
+		}
+
+		*nPtr = count
+
+		return 0
+	}
+}
+
+func MockClose(testClosable bool) {
+	MemoryViewClose = func(id uint32) (error errno.Error) {
+		if testClosable {
+			return 0
+		}
+
+		return 1
+	}
+}
+
+func MockSize(testSize uint32) {
+	MemoryViewSize = func(id uint32, sizePtr *uint32) (error errno.Error) {
+		if testSize == 0 {
+			return 1
+		}
+
+		*sizePtr = testSize
+		return 0
+	}
+}

--- a/i2mv/wasm_imports.go
+++ b/i2mv/wasm_imports.go
@@ -1,0 +1,24 @@
+//go:build wasi || wasm
+// +build wasi wasm
+
+package i2mvSym
+
+import (
+	"github.com/taubyte/go-sdk/errno"
+)
+
+//go:wasm-module taubyte/sdk
+//export memoryViewNew
+func MemoryViewNew(bufPtr *byte, size uint32, readCloser uint32, idPtr *uint32) (error errno.Error)
+
+//go:wasm-module taubyte/sdk
+//export memoryViewRead
+func MemoryViewRead(id uint32, offset uint32, count uint32, bufPtr *byte, nPtr *uint32) (error errno.Error)
+
+//go:wasm-module taubyte/sdk
+//export memoryViewClose
+func MemoryViewClose(id uint32) (error errno.Error)
+
+//go:wasm-module taubyte/sdk
+//export memoryViewSize
+func MemoryViewSize(id uint32, sizePtr *uint32) (error errno.Error)


### PR DESCRIPTION
I2mv or Inter-Module-Memory-Viewer, allows creation of a closer on one module, to be accessed by another module as a read-seek-closer. 

Current testing is between 2 golang modules, but the intention is to use this mechanism between a golanag module and another module of different language. 

sdk mock tests and examples: 
https://asciinema.org/a/49xmjdwnuypYejJQXv2vipEUm

vm-test-examples:
https://asciinema.org/a/BgAX0sIKeRNnm9WQfAY5Ow0xO