### PR TITLE
Add badges and split headers_mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # taubyte/go-sdk-symbols
 
+[![GoDoc](https://godoc.org/github.com/taubyte/go-sdk-symbols?status.svg)](https://pkg.go.dev/github.com/taubyte/go-sdk-symbols)
+[![Go Report Card](https://goreportcard.com/badge/taubyte/go-sdk-symbols)](https://goreportcard.com/report/taubyte/go-sdk-symbols)
+
 This repository imports symbols exported by the Taubyte WebAssembly Virtual Machine.
 It also, mocks outside of the VM.
 

--- a/http/client/headers_mock.go
+++ b/http/client/headers_mock.go
@@ -11,6 +11,13 @@ import (
 )
 
 func MockHeaders(testClientId uint32, testRequestId uint32, testHeaders map[string][]string) {
+	MockHeadersSet(testClientId, testRequestId, testHeaders)
+	MockHeadersGet(testClientId, testRequestId, testHeaders)
+	MockHeadersAdd(testClientId, testRequestId, testHeaders)
+	MockHeadersGetKeys(testClientId, testRequestId, testHeaders)
+}
+
+func MockHeadersSet(testClientId uint32, testRequestId uint32, testHeaders map[string][]string) {
 	SetHttpRequestHeader = func(clientId uint32, requestId uint32, key string, valuesPtr *byte, valuesSize uint32) (error errno.Error) {
 		if clientId != testClientId || requestId != testRequestId {
 			return 1
@@ -27,7 +34,9 @@ func MockHeaders(testClientId uint32, testRequestId uint32, testHeaders map[stri
 		testHeaders[key] = values
 		return 0
 	}
+}
 
+func MockHeadersGet(testClientId uint32, testRequestId uint32, testHeaders map[string][]string) {
 	GetHttpRequestHeaderSize = func(clientId uint32, requestId uint32, key string, sizePtr *uint32) (error errno.Error) {
 		if clientId != testClientId || requestId != testRequestId {
 			return 1
@@ -58,7 +67,9 @@ func MockHeaders(testClientId uint32, testRequestId uint32, testHeaders map[stri
 		copy(_data, value)
 		return 0
 	}
+}
 
+func MockHeadersAdd(testClientId uint32, testRequestId uint32, testHeaders map[string][]string) {
 	AddHttpRequestHeader = func(clientId uint32, requestId uint32, key, value string) (error errno.Error) {
 		if clientId != testClientId || requestId != testRequestId {
 			return 1
@@ -73,7 +84,9 @@ func MockHeaders(testClientId uint32, testRequestId uint32, testHeaders map[stri
 
 		return 0
 	}
+}
 
+func MockHeadersGetKeys(testClientId uint32, testRequestId uint32, testHeaders map[string][]string) {
 	GetHttpRequestHeaderKeysSize = func(clientId uint32, requestId uint32, sizePtr *uint32) (error errno.Error) {
 		if clientId != testClientId || requestId != testRequestId {
 			return 1


### PR DESCRIPTION
# taubyte/go-sdk-symbols

[![GoDoc](https://godoc.org/github.com/taubyte/go-sdk-symbols?status.svg)](https://pkg.go.dev/github.com/taubyte/go-sdk-symbols)
[![Go Report Card](https://goreportcard.com/badge/taubyte/go-sdk-symbols)](https://goreportcard.com/report/taubyte/go-sdk-symbols)

This repository imports symbols exported by the Taubyte WebAssembly Virtual Machine.
It also, mocks outside of the VM.


# Maintainers
 - Samy Fodil @samyfodil
 - Sam Stoltenberg @skelouse
 - Tafseer Khan @tafseer-khan
 - Aron Jalbuena @arontaubyte
