### PR TITLE
normalize CID calls

### DIFF
--- a/ipfs/client/imports.go
+++ b/ipfs/client/imports.go
@@ -15,7 +15,7 @@ var IpfsNewContent = func(clientId uint32, contentIdPtr *uint32) (error errno.Er
 	return 0
 }
 
-var IpfsOpenFile = func(clientId uint32, contentIdPtr *uint32, cid *byte, cidSize uint32) (error errno.Error) {
+var IpfsOpenFile = func(clientId uint32, contentIdPtr *uint32, cid *byte) (error errno.Error) {
 	return 0
 }
 

--- a/ipfs/client/mocks.go
+++ b/ipfs/client/mocks.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-sdk/errno"
-	"github.com/taubyte/go-sdk/utils/codec"
 )
 
 type mockContent struct {
@@ -74,7 +73,7 @@ func (m *MockData) Open() {
 			return 1
 		}
 
-		cidData := unsafe.Slice(cidPtr, codec.CidBufferSize)
+		cidData := unsafe.Slice(cidPtr, 64)
 		_, _cid, err := cid.CidFromBytes(cidData)
 		if err != nil {
 			return 1

--- a/ipfs/client/mocks.go
+++ b/ipfs/client/mocks.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-sdk/errno"
+	"github.com/taubyte/go-sdk/utils/codec"
 )
 
 type mockContent struct {
@@ -68,13 +69,13 @@ func (m *MockData) Create() {
 }
 
 func (m *MockData) Open() {
-	IpfsOpenFile = func(clientId uint32, contentIdPtr *uint32, cidPtr *byte, cidSize uint32) (error errno.Error) {
+	IpfsOpenFile = func(clientId uint32, contentIdPtr *uint32, cidPtr *byte) (error errno.Error) {
 		if clientId != m.ClientId {
 			return 1
 		}
 
-		cidData := unsafe.Slice(cidPtr, cidSize)
-		_cid, err := cid.Parse(cidData)
+		cidData := unsafe.Slice(cidPtr, codec.CidBufferSize)
+		_, _cid, err := cid.CidFromBytes(cidData)
 		if err != nil {
 			return 1
 		}

--- a/ipfs/client/wasm_imports.go
+++ b/ipfs/client/wasm_imports.go
@@ -17,7 +17,7 @@ func IpfsNewContent(clientId uint32, contentIdPtr *uint32) (error errno.Error)
 
 //go:wasm-module taubyte/sdk
 //export ipfsOpenFile
-func IpfsOpenFile(clientId uint32, contentIdPtr *uint32, cid *byte, cidSize uint32) (error errno.Error)
+func IpfsOpenFile(clientId uint32, contentIdPtr *uint32, cid *byte) (error errno.Error)
 
 //go:wasm-module taubyte/sdk
 //export ipfsCloseFile

--- a/storage/basic_mock.go
+++ b/storage/basic_mock.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-sdk/errno"
-	"github.com/taubyte/go-sdk/utils/codec"
 )
 
 func MockNew(testId uint32, testName string) {
@@ -48,7 +47,7 @@ func MockGet(testData map[string]uint32, expectedCid uint32) {
 
 func MockOpen(testId uint32, expectedCid string) {
 	StorageOpenCid = func(contentIdPtr *uint32, _cid *byte) (error errno.Error) {
-		cidBytes := unsafe.Slice(_cid, codec.CidBufferSize)
+		cidBytes := unsafe.Slice(_cid, 64)
 		_, testCid, err := cid.CidFromBytes(cidBytes)
 		if err != nil {
 			return 1

--- a/storage/basic_mock.go
+++ b/storage/basic_mock.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-sdk/errno"
+	"github.com/taubyte/go-sdk/utils/codec"
 )
 
 func MockNew(testId uint32, testName string) {
@@ -46,8 +47,8 @@ func MockGet(testData map[string]uint32, expectedCid uint32) {
 }
 
 func MockOpen(testId uint32, expectedCid string) {
-	StorageOpenCid = func(contentIdPtr *uint32, _cid *byte, cidSize uint32) (error errno.Error) {
-		cidBytes := unsafe.Slice(_cid, cidSize)
+	StorageOpenCid = func(contentIdPtr *uint32, _cid *byte) (error errno.Error) {
+		cidBytes := unsafe.Slice(_cid, codec.CidBufferSize)
 		_, testCid, err := cid.CidFromBytes(cidBytes)
 		if err != nil {
 			return 1

--- a/storage/content_mocks.go
+++ b/storage/content_mocks.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-sdk/errno"
-	"github.com/taubyte/go-sdk/utils/codec"
 )
 
 type contentMock struct {
@@ -64,7 +63,7 @@ func (m *ContentMockData) Create() {
 
 func (m *ContentMockData) Open() {
 	StorageOpenCid = func(contentIdPtr *uint32, cidPtr *byte) (error errno.Error) {
-		cidData := unsafe.Slice(cidPtr, codec.CidBufferSize)
+		cidData := unsafe.Slice(cidPtr, 64)
 		_, _cid, err := cid.CidFromBytes(cidData)
 		if err != nil {
 			return 1

--- a/storage/content_mocks.go
+++ b/storage/content_mocks.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-sdk/errno"
+	"github.com/taubyte/go-sdk/utils/codec"
 )
 
 type contentMock struct {
@@ -62,9 +63,9 @@ func (m *ContentMockData) Create() {
 }
 
 func (m *ContentMockData) Open() {
-	StorageOpenCid = func(contentIdPtr *uint32, cidPtr *byte, cidSize uint32) (error errno.Error) {
-		cidData := unsafe.Slice(cidPtr, cidSize)
-		_cid, err := cid.Parse(cidData)
+	StorageOpenCid = func(contentIdPtr *uint32, cidPtr *byte) (error errno.Error) {
+		cidData := unsafe.Slice(cidPtr, codec.CidBufferSize)
+		_, _cid, err := cid.CidFromBytes(cidData)
 		if err != nil {
 			return 1
 		}

--- a/storage/imports.go
+++ b/storage/imports.go
@@ -83,7 +83,7 @@ var StorageNewContent = func(contentIdPtr *uint32) (error errno.Error) {
 	return 0
 }
 
-var StorageOpenCid = func(contentIdPtr *uint32, cid *byte, cidSize uint32) (error errno.Error) {
+var StorageOpenCid = func(contentIdPtr *uint32, cid *byte) (error errno.Error) {
 	return 0
 }
 

--- a/storage/imports.go
+++ b/storage/imports.go
@@ -59,11 +59,7 @@ var StorageCapacity = func(storageId uint32, capacityPtr *byte) (error errno.Err
 	return 0
 }
 
-var StorageCidSize = func(storageId uint32, fileName string, idPtr *uint32) (error errno.Error) {
-	return 0
-}
-
-var StorageCid = func(cidPtr *byte, idPtr *uint32) (error errno.Error) {
+var StorageCid = func(storageId uint32, fileName string, cidPtr *byte) (error errno.Error) {
 	return 0
 }
 

--- a/storage/storage_mock.go
+++ b/storage/storage_mock.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"unsafe"
 
+	"github.com/ipfs/go-cid"
 	"github.com/taubyte/go-sdk/errno"
 )
 
@@ -43,26 +44,22 @@ func (m StorageMockData) MockNew() {
 }
 
 func (m StorageMockData) MockCid() {
-	StorageCidSize = func(storageId uint32, fileName string, idPtr *uint32) (error errno.Error) {
+	StorageCid = func(storageId uint32, fileName string, cidPtr *byte) (error errno.Error) {
 		if storageId != m.StorageId {
 			return 1
 		}
 
-		if m.FileName != fileName {
+		if fileName != m.FileName {
 			return 1
 		}
 
-		*idPtr = m.FileId
-		return 0
-	}
-
-	StorageCid = func(cidPtr *byte, idPtr *uint32) (error errno.Error) {
-		if *idPtr != m.FileId {
-			return 1
+		_cid, err := cid.Decode(m.Cid)
+		if err != nil {
+			return errno.ErrorInvalidCid
 		}
 
 		data := unsafe.Slice(cidPtr, len(m.Cid))
-		copy(data, []byte(m.Cid))
+		copy(data, _cid.Bytes())
 
 		return 0
 	}

--- a/storage/wasm_imports.go
+++ b/storage/wasm_imports.go
@@ -60,12 +60,8 @@ func StorageCapacitySize(storageId uint32, sizePtr *uint32) (error errno.Error)
 func StorageCapacity(storageId uint32, capacityPtr *byte) (error errno.Error)
 
 //go:wasm-module taubyte/sdk
-//export storageCidSize
-func StorageCidSize(storageId uint32, fileName string, idPtr *uint32) (error errno.Error)
-
-//go:wasm-module taubyte/sdk
 //export storageCid
-func StorageCid(cidPtr *byte, idPtr *uint32) (error errno.Error)
+func StorageCid(storageId uint32, fileName string, cidPtr *byte) (error errno.Error)
 
 //go:wasm-module taubyte/sdk
 //export storageCurrentVersionSize

--- a/storage/wasm_imports.go
+++ b/storage/wasm_imports.go
@@ -85,7 +85,7 @@ func StorageNewContent(contentIdPtr *uint32) (error errno.Error)
 
 //go:wasm-module taubyte/sdk
 //export storageOpenCid
-func StorageOpenCid(contentIdPtr *uint32, cid *byte, cidSize uint32) (error errno.Error)
+func StorageOpenCid(contentIdPtr *uint32, cid *byte) (error errno.Error)
 
 //go:wasm-module taubyte/sdk
 //export contentCloseFile


### PR DESCRIPTION
Here I normalized all calls to host reading and writing CIDs by removing the standardized CID size, and using helpers for reading and writing.